### PR TITLE
Cambio dinamico tra Alimenti Frigo e Dispensa nella pagina alimenti

### DIFF
--- a/Development/ZWH-FrontEnd/src/app/components/utility-bar/utility-bar.component.ts
+++ b/Development/ZWH-FrontEnd/src/app/components/utility-bar/utility-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { navigationBtnComponent } from '../navigationBtn/navigationBtn.component';
 import { NgClass, NgForOf } from '@angular/common';
 
@@ -18,11 +18,14 @@ export class UtilityBarComponent {
 
   @Input() title: string = ''; // Proprietà per il titolo
 
+  @Output() labelChanged = new EventEmitter<string>();
+
   // se la label viene cliccata esegue un operazione che aggiorna activeLabel
   onLabelClick(label: { title: string }) {
     if (this.activeLabel !== label.title) {
       console.log(`Etichetta cliccata: ${label.title}`);
       this.activeLabel = label.title; // Aggiorna l'etichetta attiva
+      this.labelChanged.emit(this.activeLabel); // Notifica al genitore
     }
   }
 

--- a/Development/ZWH-FrontEnd/src/app/pages/pagina-alimenti/pagina-alimenti.component.html
+++ b/Development/ZWH-FrontEnd/src/app/pages/pagina-alimenti/pagina-alimenti.component.html
@@ -5,6 +5,7 @@
   [labels]="labels"
   [buttons]="buttons"
   [title]="tableTitle"
+  (labelChanged)="onLabelChange($event)"
 ></utility-bar>
 <product-table id="productTable" [products]="productList" [buttuns]="buttonList">></product-table>
 <app-footer></app-footer>

--- a/Development/ZWH-FrontEnd/src/app/pages/pagina-alimenti/pagina-alimenti.component.ts
+++ b/Development/ZWH-FrontEnd/src/app/pages/pagina-alimenti/pagina-alimenti.component.ts
@@ -62,4 +62,10 @@ export class PaginaAlimentiComponent {
 
   // Proprietà per i buttons relativi ad ogni prodotto
   buttonList = ['Visualizza', 'Modifica', 'Elimina'];
+
+  onLabelChange(newLabel: string) {
+    this.items = [
+      { label: newLabel === 'Frigo' ? 'Alimenti Frigo' : 'Alimenti Dispensa', routerLink: '/' },
+    ];
+  }
 }


### PR DESCRIPTION
## Descrizione

Questa PR consente al componente padre `PaginaAlimentiComponent` di conoscere lo stato del componente figlio `utility-bar`, migliorando l'integrazione tra i due. La modifica permette di aggiornare dinamicamente il breadcrumb e di utilizzare l'etichetta attiva per altre funzionalità.  

1. **Componente figlio (`utility-bar`)**  
   È stato introdotto il decoratore `@Output()` `labelChanged`, che emette un evento contenente il nome dell'etichetta attiva selezionata ("Frigo" o "Dispensa"). Questo consente al componente figlio di notificare il proprio stato al componente padre.

2. **Componente padre (`PaginaAlimentiComponent`)**  
   Il componente padre è stato aggiornato per ascoltare l'evento `labelChanged` e gestirlo tramite la funzione `onLabelChange`, che aggiorna dinamicamente il path del breadcrumb con il valore dell'etichetta ricevuto.

3. **Integrazione con altre funzionalità**  
   L'etichetta attiva ("Frigo" o "Dispensa") è ora accessibile al componente padre. Questa modifica potrà essere utile anche ad altre funzionalità: ad esempio, il pulsante "Add Aliments" potrà utilizzare questo valore per determinare correttamente il routing.

### Obiettivo
L'obiettivo principale è consentire al componente padre di conoscere lo stato del componente figlio, rendendo l'interazione tra i due più dinamica.