### PR TITLE
Creazione pagina risoluzione segnalazione ricetta da parte del gestore e collegamento all'endpoint del backend

### DIFF
--- a/Development/ZWH-BackEnd/src/main/java/it/unisa/zwhbackend/model/entity/SegnalazioneRicetta.java
+++ b/Development/ZWH-BackEnd/src/main/java/it/unisa/zwhbackend/model/entity/SegnalazioneRicetta.java
@@ -1,5 +1,6 @@
 package it.unisa.zwhbackend.model.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import it.unisa.zwhbackend.model.enums.StatoSegnalazione;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -67,6 +68,7 @@ public class SegnalazioneRicetta {
   @ManyToOne // Relazione molti-a-uno con l'entità GestoreCommunity
   @JoinColumn(name = "gestore_id") // Collega questa entità alla colonna 'gestore_id' della tabella
   // 'segnalazione_ricetta'
+  @JsonIgnore
   private GestoreCommunity gestoreAssociato; // Il gestore che ha preso in carico la segnalazione
 
   /**
@@ -82,6 +84,7 @@ public class SegnalazioneRicetta {
   @JoinColumn(
       name = "ricetta_id",
       nullable = true) // La colonna 'ricetta_id' è opzionale (nullable = true)
+  @JsonIgnore
   private Ricetta ricettaAssociato; // La ricetta associata a questa segnalazione (può essere null)
 
   /**

--- a/Development/ZWH-BackEnd/src/main/java/it/unisa/zwhbackend/service/gestioneAmministrativa/GestioneSegnalazioneRicettaService.java
+++ b/Development/ZWH-BackEnd/src/main/java/it/unisa/zwhbackend/service/gestioneAmministrativa/GestioneSegnalazioneRicettaService.java
@@ -4,6 +4,7 @@ import it.unisa.zwhbackend.model.entity.*;
 import it.unisa.zwhbackend.model.enums.StatoSegnalazione;
 import it.unisa.zwhbackend.model.repository.*;
 import java.time.LocalDate;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -166,6 +167,15 @@ public class GestioneSegnalazioneRicettaService implements SegnalazioneRicettaSe
     return ricettaRepository
         .findById(segnalazioneRicetta.getRicettaAssociato().getId())
         .orElseThrow(() -> new RuntimeException("Ricetta non trovata."));
+  }
+
+  /**
+   * Recupera tutte le segnalazioni.
+   *
+   * @return Lista di tutte le segnalazioni presenti nel sistema
+   */
+  public List<SegnalazioneRicetta> getAllSegnalazioni() {
+    return segnalazioneRicettaRepository.findAll(); // Utilizza il repository per recuperare i dati
   }
 
   /**

--- a/Development/ZWH-BackEnd/src/main/java/it/unisa/zwhbackend/service/gestioneAmministrativa/SegnalazioneRicettaService.java
+++ b/Development/ZWH-BackEnd/src/main/java/it/unisa/zwhbackend/service/gestioneAmministrativa/SegnalazioneRicettaService.java
@@ -1,5 +1,8 @@
 package it.unisa.zwhbackend.service.gestioneAmministrativa;
 
+import it.unisa.zwhbackend.model.entity.SegnalazioneRicetta;
+import java.util.List;
+
 /**
  * Interfaccia per la gestione delle segnalazioni nel sistema.
  *
@@ -24,4 +27,6 @@ public interface SegnalazioneRicettaService {
    *     errori.
    */
   String risolviSegnalazione(Long segnalazioneId, String gestore_id, String motivoBlocco);
+
+  List<SegnalazioneRicetta> getAllSegnalazioni();
 }

--- a/Development/ZWH-BackEnd/src/main/java/it/unisa/zwhbackend/web/controller/gestioneAmministrativa/SegnalazioneRicettaController.java
+++ b/Development/ZWH-BackEnd/src/main/java/it/unisa/zwhbackend/web/controller/gestioneAmministrativa/SegnalazioneRicettaController.java
@@ -1,7 +1,7 @@
 package it.unisa.zwhbackend.web.controller.gestioneAmministrativa;
 
-import it.unisa.zwhbackend.service.gestioneAmministrativa.AmministrazioneService;
 import it.unisa.zwhbackend.model.entity.SegnalazioneRicetta;
+import it.unisa.zwhbackend.service.gestioneAmministrativa.AmministrazioneService;
 import it.unisa.zwhbackend.service.gestioneAmministrativa.SegnalazioneRicettaService;
 import java.util.List;
 import java.util.Map;
@@ -11,9 +11,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 /**
- * Controller per la gestione delle segnalazioni relative alle ricette.
- * Fornisce endpoint per ottenere tutte le segnalazioni e per risolvere
- * una segnalazione specifica.
+ * Controller per la gestione delle segnalazioni relative alle ricette. Fornisce endpoint per
+ * ottenere tutte le segnalazioni e per risolvere una segnalazione specifica.
  *
  * @author Giovanni Balzano
  */
@@ -24,6 +23,7 @@ public class SegnalazioneRicettaController {
   // Variabile per memorizzare il servizio che gestisce le segnalazioni
   private final AmministrazioneService amministrazioneService;
   private final SegnalazioneRicettaService segnalazioneRicettaService;
+
   /**
    * Costruttore del controller per l'inizializzazione del servizio delle segnalazioni.
    *
@@ -34,7 +34,9 @@ public class SegnalazioneRicettaController {
    *     gestione amministrativa
    * @param segnalazioneRicettaService il servizio per la gestione delle segnalazioni di ricette
    */
-  public SegnalazioneRicettaController(AmministrazioneService amministrazioneService, SegnalazioneRicettaService segnalazioneRicettaService) {
+  public SegnalazioneRicettaController(
+      AmministrazioneService amministrazioneService,
+      SegnalazioneRicettaService segnalazioneRicettaService) {
     this.amministrazioneService = amministrazioneService;
     this.segnalazioneRicettaService = segnalazioneRicettaService;
   }
@@ -43,7 +45,7 @@ public class SegnalazioneRicettaController {
    * Endpoint per ottenere tutte le segnalazioni di ricette.
    *
    * @return una ResponseEntity contenente la lista delle segnalazioni e lo stato HTTP OK (200)
-   *         oppure lo stato HTTP INTERNAL_SERVER_ERROR (500) in caso di errore
+   *     oppure lo stato HTTP INTERNAL_SERVER_ERROR (500) in caso di errore
    */
   @GetMapping
   public ResponseEntity<List<SegnalazioneRicetta>> getSegnalazioni() {
@@ -62,24 +64,24 @@ public class SegnalazioneRicettaController {
    *
    * @param id l'identificativo univoco della segnalazione da risolvere
    * @param body una mappa contenente il motivo del blocco come chiave "motivoBlocco"
-   * @return una ResponseEntity contenente un messaggio di successo o di errore,
-   *         e il relativo stato HTTP (200 per successo, 400 per errore di input)
+   * @return una ResponseEntity contenente un messaggio di successo o di errore, e il relativo stato
+   *     HTTP (200 per successo, 400 per errore di input)
    */
   @PatchMapping("/{id}")
   public ResponseEntity<String> risolviSegnalazione(
       @PathVariable Long id, @RequestBody Map<String, String> body) {
     // Chiama il servizio per risolvere la segnalazione con l'ID fornito
-      String motivoBlocco = body.get("motivoBlocco");
-      if (motivoBlocco == null || motivoBlocco.trim().isEmpty()) {
-          return ResponseEntity.badRequest().body("Motivo del blocco è obbligatorio.");
-      }
+    String motivoBlocco = body.get("motivoBlocco");
+    if (motivoBlocco == null || motivoBlocco.trim().isEmpty()) {
+      return ResponseEntity.badRequest().body("Motivo del blocco è obbligatorio.");
+    }
 
-      // Recupera l'email del gestore autenticato
-      String email = SecurityContextHolder.getContext().getAuthentication().getName();
+    // Recupera l'email del gestore autenticato
+    String email = SecurityContextHolder.getContext().getAuthentication().getName();
 
-      // Passa l'email al servizio
-      String response = amministrazioneService.risolviSegnalazioneRicetta(id, email, motivoBlocco);
-      if (response.contains("successo")) {
+    // Passa l'email al servizio
+    String response = amministrazioneService.risolviSegnalazioneRicetta(id, email, motivoBlocco);
+    if (response.contains("successo")) {
       return ResponseEntity.ok(response);
     }
     return ResponseEntity.badRequest().body(response);

--- a/Development/ZWH-FrontEnd/src/app/components/textbox-motivazione/textbox-motivazione.component.css
+++ b/Development/ZWH-FrontEnd/src/app/components/textbox-motivazione/textbox-motivazione.component.css
@@ -1,0 +1,39 @@
+/* Stili per la modale */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  width: 80%;
+  max-width: 600px;
+  position: relative; /* Necessario per posizionare correttamente la "X" */
+}
+
+/* Stili per il pulsante X */
+.close-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: 24px;
+  font-weight: bold;
+  color: #333;
+  cursor: pointer;
+  border: none;
+  background: none;
+}
+
+.close-btn:hover {
+  color: red; /* Colore rosso per l'effetto hover */
+}

--- a/Development/ZWH-FrontEnd/src/app/components/textbox-motivazione/textbox-motivazione.component.html
+++ b/Development/ZWH-FrontEnd/src/app/components/textbox-motivazione/textbox-motivazione.component.html
@@ -1,0 +1,31 @@
+<div *ngIf="showModal" class="modal-overlay">
+  <div class="modal-content">
+    <!-- Icona X per chiudere la modale -->
+    <span class="close-btn" (click)="closeModal()">×</span>
+
+    <div style="display: flex; flex-direction: column; align-items: center; margin-top: 2rem">
+      <h2>Inserisci la motivazione del blocco</h2>
+      <textarea
+        rows="8"
+        cols="60"
+        placeholder="Scrivi qui la motivazione..."
+        [(ngModel)]="motivazione"
+        style="
+          border: 2px solid #ccc;
+          border-radius: 10px;
+          padding: 15px;
+          font-size: 18px;
+          width: 90%;
+          max-width: 550px;
+          height: 225px;
+        "
+      ></textarea>
+
+      <app-bottone-conferma-azione
+        [text]="'Invia'"
+        style="font-size: 18px; padding: 12px 24px; width: 150px; height: 50px"
+        (click)="submitMotivazione()"
+      ></app-bottone-conferma-azione>
+    </div>
+  </div>
+</div>

--- a/Development/ZWH-FrontEnd/src/app/components/textbox-motivazione/textbox-motivazione.component.spec.ts
+++ b/Development/ZWH-FrontEnd/src/app/components/textbox-motivazione/textbox-motivazione.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TextboxMotivazioneComponent } from './textbox-motivazione.component';
+
+describe('TextboxMotivazioneComponent', () => {
+  let component: TextboxMotivazioneComponent;
+  let fixture: ComponentFixture<TextboxMotivazioneComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TextboxMotivazioneComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TextboxMotivazioneComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Development/ZWH-FrontEnd/src/app/components/textbox-motivazione/textbox-motivazione.component.ts
+++ b/Development/ZWH-FrontEnd/src/app/components/textbox-motivazione/textbox-motivazione.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+import { TextboxMotivazioneModalService } from '../../services/servizio-motivazione-blocco/textbox-motivazione-blocco.service';
+import { FormsModule } from '@angular/forms';
+import { BottoneConfermaAzioneComponent } from '../bottone-conferma-azione/bottone-conferma-azione.component';
+import { NgIf } from '@angular/common';
+
+@Component({
+  selector: 'app-textbox-motivazione-blocco',
+  templateUrl: './textbox-motivazione.component.html',
+  styleUrls: ['./textbox-motivazione.component.css'],
+  standalone: true,
+  imports: [FormsModule, BottoneConfermaAzioneComponent, NgIf],
+})
+export class TextBoxMotivazioneModalComponent implements OnInit {
+  showModal: boolean = false;
+  motivazione: string = '';
+
+  constructor(private modalService: TextboxMotivazioneModalService) {}
+
+  ngOnInit() {
+    // Iscriviti allo stato della modale
+    this.modalService.showModal$.subscribe(isVisible => {
+      this.showModal = isVisible;
+    });
+  }
+
+  // Funzione per chiudere la modale
+  closeModal() {
+    this.modalService.closeModal();
+  }
+
+  // Funzione per inviare la motivazione (placeholder per il salvataggio)
+  submitMotivazione() {
+    console.log('Motivazione inviata:', this.motivazione);
+    this.closeModal(); // Chiudi la modale dopo l'invio
+  }
+}

--- a/Development/ZWH-FrontEnd/src/app/pages/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore.component.html
+++ b/Development/ZWH-FrontEnd/src/app/pages/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore.component.html
@@ -1,0 +1,31 @@
+<app-header barra_ricerca="no" loggato="si"></app-header>
+
+<table>
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Contenuto</th>
+      <th>Stato</th>
+      <th>Ricetta</th>
+      <th>Gestore</th>
+      <th>Azioni</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let segnalazione of segnalazioni">
+      <td>{{ segnalazione.id }}</td>
+      <td>{{ segnalazione.contenuto }}</td>
+      <td>{{ segnalazione.stato }}</td>
+      <td>{{ segnalazione.ricettaAssociato?.nome || 'N/A' }}</td>
+      <td>{{ segnalazione.gestoreAssociato?.nome || 'N/A' }}</td>
+      <td>
+        <navigationBtn
+          label="Blocca Autore"
+          (click)="onBloccaAutoreClick(segnalazione.id)"
+        ></navigationBtn>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<app-footer></app-footer>

--- a/Development/ZWH-FrontEnd/src/app/pages/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore.component.spec.ts
+++ b/Development/ZWH-FrontEnd/src/app/pages/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SegnalazioneRicettaGestoreComponent } from './segnalazione-ricetta-gestore.component';
+
+describe('SegnalazioneRicettaGestoreComponent', () => {
+  let component: SegnalazioneRicettaGestoreComponent;
+  let fixture: ComponentFixture<SegnalazioneRicettaGestoreComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SegnalazioneRicettaGestoreComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SegnalazioneRicettaGestoreComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Development/ZWH-FrontEnd/src/app/pages/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore.component.ts
+++ b/Development/ZWH-FrontEnd/src/app/pages/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnInit } from '@angular/core';
+import { SegnalazioneRicettaService } from '../../../services/servizio-segnalazione-ricetta-gestore/segnalazione-ricetta.service';
+import { HeaderComponent } from '../../../components/header/header.component';
+import { BreadcrumbComponent } from '../../../components/breadcrumb/breadcrumb.component';
+import { FooterComponent } from '../../../components/footer/footer.component';
+import { CommonModule } from '@angular/common';
+import { navigationBtnComponent } from '../../../components/navigationBtn/navigationBtn.component';
+
+@Component({
+  selector: 'app-segnalazione-ricetta-gestore',
+  templateUrl: './segnalazione-ricetta-gestore.component.html',
+  styleUrls: ['./segnalazione-ricetta-gestore.component.css'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    HeaderComponent,
+    BreadcrumbComponent,
+    FooterComponent,
+    navigationBtnComponent,
+  ],
+})
+export class SegnalazioneRicettaGestoreComponent implements OnInit {
+  segnalazioni: any[] = []; // Array per le segnalazioni
+
+  constructor(private segnalazioneService: SegnalazioneRicettaService) {}
+
+  ngOnInit() {
+    this.caricaSegnalazioni();
+  }
+
+  caricaSegnalazioni() {
+    this.segnalazioneService.getSegnalazioni().subscribe({
+      next: data => {
+        this.segnalazioni = data; // Popola l'array con le segnalazioni
+      },
+      error: error => {
+        console.error('Errore durante il caricamento delle segnalazioni:', error);
+      },
+    });
+  }
+
+  onBloccaAutoreClick(id: number) {
+    const motivoBlocco = prompt('Inserisci il motivo del blocco:') || '';
+    if (!motivoBlocco.trim()) {
+      alert('Motivo del blocco obbligatorio!');
+      return;
+    }
+    console.log(motivoBlocco);
+    this.segnalazioneService.risolviSegnalazione(id, motivoBlocco).subscribe({
+      next: response => {
+        console.log('Segnalazione risolta:', response);
+        alert('Segnalazione risolta con successo!');
+        this.caricaSegnalazioni(); // Aggiorna la lista delle segnalazioni
+      },
+      error: error => {
+        console.error('Errore durante la risoluzione della segnalazione:', error);
+        alert('Errore durante la risoluzione della segnalazione!');
+      },
+    });
+  }
+}

--- a/Development/ZWH-FrontEnd/src/app/routes.ts
+++ b/Development/ZWH-FrontEnd/src/app/routes.ts
@@ -14,6 +14,7 @@ import { PaginaRicetteUtenteComponent } from './pages/pagina-ricette-utente/pagi
 import { SegnalazioneRicettaComponent } from './pages/segnalazione-ricetta/segnalazione-ricetta.component';
 import { AuthGuard } from './guards/auth.guard';
 import { LoginGestoreComponent } from './pages/login-gestore/login-gestore.component';
+import { SegnalazioneRicettaGestoreComponent } from './pages/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore/segnalazione-ricetta-gestore.component';
 
 export const routes: Routes = [
   { path: '', component: HomeUtenteNonLoggatoComponent }, // Home page
@@ -99,6 +100,11 @@ export const routes: Routes = [
     path: 'segnalazione-ricetta',
     component: SegnalazioneRicettaComponent,
     data: { breadcrumb: 'Segnalazione Ricetta' },
+    canActivate: [AuthGuard],
+  },
+  {
+    path: 'pagina-gestore',
+    component: SegnalazioneRicettaGestoreComponent,
     canActivate: [AuthGuard],
   },
   {

--- a/Development/ZWH-FrontEnd/src/app/services/servizio-motivazione-blocco/textbox-motivazione-blocco.service.spec.ts
+++ b/Development/ZWH-FrontEnd/src/app/services/servizio-motivazione-blocco/textbox-motivazione-blocco.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TextboxMotivazioneModalService } from './textbox-motivazione-blocco.service';
+
+describe('TextboxMotivazioneBloccoService', () => {
+  let service: TextboxMotivazioneModalService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TextboxMotivazioneModalService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/Development/ZWH-FrontEnd/src/app/services/servizio-motivazione-blocco/textbox-motivazione-blocco.service.ts
+++ b/Development/ZWH-FrontEnd/src/app/services/servizio-motivazione-blocco/textbox-motivazione-blocco.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TextboxMotivazioneModalService {
+  private showModalSubject = new Subject<boolean>();
+  private motivoBlocco: string = ''; // Proprietà per memorizzare il motivo del blocco
+
+  // Observable per ascoltare la visibilità della modale
+  showModal$ = this.showModalSubject.asObservable();
+
+  // Funzione per aprire la modale
+  openModal() {
+    this.showModalSubject.next(true);
+  }
+
+  // Funzione per chiudere la modale
+  closeModal() {
+    this.showModalSubject.next(false);
+  }
+
+  // Funzione per impostare il motivo del blocco
+  setMotivoBlocco(motivo: string): void {
+    this.motivoBlocco = motivo;
+  }
+
+  // Funzione per ottenere il motivo del blocco
+  getMotivoBlocco(): string {
+    return this.motivoBlocco;
+  }
+}

--- a/Development/ZWH-FrontEnd/src/app/services/servizio-segnalazione-ricetta-gestore/segnalazione-ricetta.service.spec.ts
+++ b/Development/ZWH-FrontEnd/src/app/services/servizio-segnalazione-ricetta-gestore/segnalazione-ricetta.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SegnalazioneRicettaService } from './segnalazione-ricetta.service';
+
+describe('SegnalazioneRicettaService', () => {
+  let service: SegnalazioneRicettaService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SegnalazioneRicettaService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/Development/ZWH-FrontEnd/src/app/services/servizio-segnalazione-ricetta-gestore/segnalazione-ricetta.service.ts
+++ b/Development/ZWH-FrontEnd/src/app/services/servizio-segnalazione-ricetta-gestore/segnalazione-ricetta.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SegnalazioneRicettaService {
+  private apiUrl = `${environment.apiUrl}/utente/gestoreSegnalazioni`;
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Metodo per ottenere tutte le segnalazioni dal backend
+   * @returns Observable contenente un array di segnalazioni
+   */
+  getSegnalazioni(): Observable<any[]> {
+    return this.http.get<any[]>(this.apiUrl); // Effettua una GET sull'endpoint
+  }
+
+  /**
+   * Metodo per risolvere una segnalazione tramite una chiamata PATCH
+   * @param id ID della segnalazione da risolvere
+   * @param motivoBlocco Motivo del blocco
+   * @returns Observable con la risposta del backend
+   */
+  risolviSegnalazione(id: number, motivoBlocco: string): Observable<string> {
+    const body = { motivoBlocco };
+    return this.http.patch<string>(`${this.apiUrl}/${id}`, body);
+  }
+}


### PR DESCRIPTION
Implementata la pagina per la risoluzione delle segnalazioni di ricette da parte del gestore. Aggiunto il collegamento all'endpoint del backend per la gestione delle segnalazioni, includendo la possibilità di inviare il motivo del blocco tramite richiesta PATCH. La pagina consente al gestore di visualizzare e interagire con le segnalazioni in modo efficiente.
